### PR TITLE
running jobs in standard queue

### DIFF
--- a/.run_file_download_stats.sh
+++ b/.run_file_download_stats.sh
@@ -8,7 +8,7 @@
 JOB1_NAME="file-downloads-stat-copy-data"
 JOB2_NAME="file-downloads-stat-analysis"
 # memory limit
-MEMORY_LIMIT=12G
+MEMORY_LIMIT=7G
 #email notification
 JOB_EMAIL="pride-report@ebi.ac.uk"
 

--- a/.run_file_download_stats.sh
+++ b/.run_file_download_stats.sh
@@ -5,26 +5,60 @@
 
 ##### VARIABLES
 # the name to give to the job - do not use spaces
-JOB_NAME="file-downloads-statistics"
+JOB1_NAME="file-downloads-stat-copy-data"
+JOB2_NAME="file-downloads-stat-analysis"
 # memory limit
 MEMORY_LIMIT=12G
 #email notification
 JOB_EMAIL="pride-report@ebi.ac.uk"
 
+LOGS_SOURCE_ROOT=$LOGS_SOURCE_ROOT
+LOGS_DESTINATION_ROOT=$LOGS_DESTINATION_ROOT
 
 ##### FUNCTIONS
 printUsage() {
     echo "Description: a pipeline to calculate number of file downloads"
-    echo "$ ./scripts/runFileDownloadStats.sh"
+    echo "$ ./runFileDownloadStats.sh"
     echo ""
     echo "Usage: ./runFileDownloadStats.sh"
     echo "     Example: ./runFileDownloadStats.sh"
 }
 
+if [ -z "$LOGS_SOURCE_ROOT" ]; then
+    echo "LOGS_SOURCE_ROOT is not set!"
+    exit 1
+fi
+if [ -z "$LOGS_DESTINATION_ROOT" ]; then
+    echo "LOGS_DESTINATION_ROOT is not set!"
+    exit 1
+fi
+
+
 DATE=$(date +"%Y%m%d%H%M")
 
 ##### Change directory to where the script locate
 cd ${0%/*}
+
+#### RUN the first job on the cluster #####
+JOB_ID=$(sbatch --time=00:07:00  \
+    --mem="${MEMORY_LIMIT}" \
+    -p datamover \
+    --mail-type=ALL \
+    --mail-user="${JOB_EMAIL}" \
+    --job-name="${JOB1_NAME}" <<EOF
+#!/bin/bash
+rsync -ah --progress --stats \
+    "${LOGS_SOURCE_ROOT}/fasp-aspera/public" \
+    "${LOGS_SOURCE_ROOT}/ftp/public" \
+    "${LOGS_SOURCE_ROOT}/gridftp-globus/public" \
+    "${LOGS_SOURCE_ROOT}/http/public" \
+    "${LOGS_DESTINATION_ROOT}/"
+EOF
+)
+
+
+# Extract the job ID from the sbatch output (e.g., "Submitted batch job 12345") This removes everything up to the first space, leaving only the job ID
+JOB_ID=${JOB_ID##* }
 
 ${CONDA_INIT}
 conda activate file_download_stat
@@ -36,5 +70,6 @@ sbatch -t 7-0 \
      -p standard \
      --mail-type=ALL \
      --mail-user=${JOB_EMAIL} \
-     --job-name=${JOB_NAME} \
+     --job-name=${JOB2_NAME} \
+     --dependency=afterok:${JOB_ID} \
      ./scripts/run_stat.sh ${PROFILE}

--- a/main.nf
+++ b/main.nf
@@ -52,7 +52,7 @@ api_endpoint_file_downloads_per_file    : ${params.api_endpoint_file_downloads_p
 
 process get_log_files {
 
-    label 'data_mover'
+//     label 'data_mover'
 
     input:
     val root_dir
@@ -90,7 +90,7 @@ process run_log_file_stat{
 process process_log_file {
 
     label 'process_very_low'
-    label 'data_mover'
+//     label 'data_mover'
 
 
     input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,7 @@ profiles {
   ebislurm {
     executor {
             name = "slurm"
-            queueSize = 5
+            queueSize = 1000
             submitRateLimit = "10/1sec"
             exitReadTimeout = "30 min"
             queueGlobalStatus = true


### PR DESCRIPTION
Data is currently only accessible for datamover node. So copied data to a place where standard node can access data and run lot of jobs simultaneously in standard queue